### PR TITLE
Projects Registration improvements

### DIFF
--- a/docs/accounts-and-projects/projects.md
+++ b/docs/accounts-and-projects/projects.md
@@ -71,7 +71,8 @@ The project will also need to be added to the OSG Topology repo at
     Within your forked repository, copy `template-project.yaml` into a new project file in the
     `projects` folder.
     The project file should be named the same as the short (UNIX) project name.
-    Fill in the appropriate information.
+    Fill in the appropriate information -- use the same values that you used on the OSGConnect.net
+    portal.
 
     If you made the project for a new organization, or an organization that didn't have a
     "Project Prefix" in the [project organizations list page](https://topology.opensciencegrid.org/organizations),

--- a/docs/accounts-and-projects/projects.md
+++ b/docs/accounts-and-projects/projects.md
@@ -24,6 +24,13 @@ Project Description:
 Please only use [NSF-aligned Field of Sciences](https://osp.unm.edu/pi-resources/nsf-research-classifications.html) 
 for the "Field of Science". 
 
+Note: the convention for "Project Name" for non-XSEDE projects is `<SHORT INSTITUTION>_<PI LAST NAME>`
+where `<SHORT INSTITUTION>` is an abbreviation or short version of the organization name.
+For example, for "University of Wisconsin-Madison" we use "UWMadison".
+For consistency, there is a list of previously used short versions in the
+[project/institution mappings file](https://github.com/opensciencegrid/topology/blob/master/mappings/project_institution.yaml).
+If the organization is not in that file, you should add it later when you register the project in topology.
+
 Click "Submit" to add the new project.
 
 ## Add the user to the project
@@ -66,6 +73,9 @@ https://github.com/opensciencegrid/topology/tree/master/projects
     In order to maintain consistency in organization naming structure, please use the `bin/list_organizations` 
     function to ensure the name you are using matches this list.
 
-    
+    If you made a project for an organization that was not listed in the
+    [project/institution mappings file](https://github.com/opensciencegrid/topology/blob/master/mappings/project_institution.yaml),
+    edit that file to add the prefix and the organization you used.
+    (You can skip this for XSEDE projects.)
 
 3.  Commit the new project file and submit a PR. 

--- a/docs/accounts-and-projects/projects.md
+++ b/docs/accounts-and-projects/projects.md
@@ -26,9 +26,10 @@ for the "Field of Science".
 
 Note: the convention for "Project Name" for non-XSEDE projects is `<SHORT INSTITUTION>_<PI LAST NAME>`
 where `<SHORT INSTITUTION>` is an abbreviation or short version of the organization name.
-For example, for "University of Wisconsin-Madison" we use "UWMadison".
-For consistency, there is a list of previously used short versions in the
+For example, abbreviate "University of Wisconsin-Madison" as "UWMadison".
+There is a list of previously used short versions in the
 [project/institution mappings file](https://github.com/opensciencegrid/topology/blob/master/mappings/project_institution.yaml).
+For consistency, if you find the organization in that file, use its corresponding abbreviation.
 If the organization is not in that file, you should add it later when you register the project in topology.
 
 Click "Submit" to add the new project.

--- a/docs/accounts-and-projects/projects.md
+++ b/docs/accounts-and-projects/projects.md
@@ -68,13 +68,10 @@ The project will also need to be added to the OSG Topology repo at
     clicking "Fork". Detailed information for setting up and maintaining your fork can be found
     in the [GitHub documentation page](../documentation/github.md).
 
-    Within your forked repository, go into the projects folder and create a project file. 
-    The project file should be named the same as the short (UNIX) project name. 
-    It usually makes sense to copy from another project 
-    file that was also created for an OSG Connect project so the 
-    sponsor information is already correct.  Fill in the appropriate information.
-
-    Note: some projects may have `ID` or `Name` fields; these are no longer necessary.
+    Within your forked repository, copy `template-project.yaml` into a new project file in the
+    `projects` folder.
+    The project file should be named the same as the short (UNIX) project name.
+    Fill in the appropriate information.
 
     If you made the project for a new organization, or an organization that didn't have a
     "Project Prefix" in the [project organizations list page](https://topology.opensciencegrid.org/organizations),

--- a/docs/accounts-and-projects/projects.md
+++ b/docs/accounts-and-projects/projects.md
@@ -29,7 +29,7 @@ Click "Submit" to add the new project.
 ## Add the user to the project
 
 After the project file has been created, add the required users to the project. 
-If you are doing this step immediately after creating the project, skip to step <<number>> below
+If you are doing this step immediately after creating the project, skip to step 4 below
 
 1. Go to https://www.osgconnect.net and login
 2. Click on the "Projects" tab on the Admin panel
@@ -50,13 +50,8 @@ git clone https://github.com/opensciencegrid/topology
 cd topology
 ```
 
-2. Run the "next project id" script in the bin/ directory:
-```
-bin/next_project_id
-```
-That will give you the ID number for the new project.  
 
-3. To add a new project file, you will need to ensure you are working
+2. To add a new project file, you will need to ensure you are working
 within your own (forked) version of the repository. If you have not already
 done so, fork the topology repository by visiting https://github.com/opensciencegrid/topology, 
 clicking "Fork". Detailed information for setting up and maintaining your fork can be found
@@ -66,10 +61,11 @@ Within your forked repository, go into the projects folder and create a project 
 The project file should be named the same as the short (UNIX) project name. 
 It usually makes sense to copy from another project 
 file that was also created for an OSG Connect project so the 
-sponsor information is already correct.  Fill in the appropriate information, including the ID number 
-you got from the previous step.
+sponsor information is already correct.  Fill in the appropriate information.
 
-In order to maintain consistancy in organization naming structure, please use the `bin/list_organizations` 
+Note: some projects may have `ID` or `Name` fields; these are no longer necessary.
+
+In order to maintain consistency in organization naming structure, please use the `bin/list_organizations` 
 function to ensure the name you are using matches this list.
 
-4. Commit the new project file and submit a PR. 
+3. Commit the new project file and submit a PR. 

--- a/docs/accounts-and-projects/projects.md
+++ b/docs/accounts-and-projects/projects.md
@@ -22,15 +22,20 @@ Project Description:
 ```
 
 Please only use [NSF-aligned Field of Sciences](https://osp.unm.edu/pi-resources/nsf-research-classifications.html) 
-for the "Field of Science". 
+for the "Field of Science".
+
+For "PI Organization", visit the [project organizations list](https://topology.opensciencegrid.org/organizations)
+to see if the organization is already used in another project.  If so, be sure to use the same spelling
+and punctuation in your own entry, so we don't have duplicate organizations with different spellings.
 
 Note: the convention for "Project Name" for non-XSEDE projects is `<SHORT INSTITUTION>_<PI LAST NAME>`
 where `<SHORT INSTITUTION>` is an abbreviation or short version of the organization name.
 For example, abbreviate "University of Wisconsin-Madison" as "UWMadison".
-There is a list of previously used short versions in the
+The "Project Prefix" column in the [project organizations list](https://topology.opensciencegrid.org/organizations)
+contains what you should use for `<SHORT INSTITUTION>` for that organization.  If the organization is not
+there, or the Project Prefix column is blank, pick something appropriate; you should later add it to the
 [project/institution mappings file](https://github.com/opensciencegrid/topology/blob/master/mappings/project_institution.yaml).
-For consistency, if you find the organization in that file, use its corresponding abbreviation.
-If the organization is not in that file, you should add it later when you register the project in topology.
+when you register the project in Topology.
 
 Click "Submit" to add the new project.
 
@@ -46,11 +51,11 @@ If you are doing this step immediately after creating the project, skip to step 
 5. Add the user to the project by clicking the "Add Member" button next to their entry
 
 
-## Add the project to `topology`
+## Add the project to OSG Topology
 
-The project will also need to be added to the OSG topology at 
+The project will also need to be added to the OSG Topology repo at 
 
-https://github.com/opensciencegrid/topology/tree/master/projects
+<https://github.com/opensciencegrid/topology/tree/master/projects>
 
 1.  Clone the topology repository and `cd` into it.
 
@@ -59,7 +64,7 @@ https://github.com/opensciencegrid/topology/tree/master/projects
 
 2.  To add a new project file, you will need to ensure you are working
     within your own (forked) version of the repository. If you have not already
-    done so, fork the topology repository by visiting https://github.com/opensciencegrid/topology, 
+    done so, fork the topology repository by visiting <https://github.com/opensciencegrid/topology>,
     clicking "Fork". Detailed information for setting up and maintaining your fork can be found
     in the [GitHub documentation page](../documentation/github.md).
 
@@ -71,12 +76,11 @@ https://github.com/opensciencegrid/topology/tree/master/projects
 
     Note: some projects may have `ID` or `Name` fields; these are no longer necessary.
 
-    In order to maintain consistency in organization naming structure, please use the `bin/list_organizations` 
-    function to ensure the name you are using matches this list.
+    If you made the project for a new organization, or an organization that didn't have a
+    "Project Prefix" in the [project organizations list page](https://topology.opensciencegrid.org/organizations),
+    edit the [project/institution mappings file](https://github.com/opensciencegrid/topology/blob/master/mappings/project_institution.yaml),
+    and add the mapping for the prefix you used.
 
-    If you made a project for an organization that was not listed in the
-    [project/institution mappings file](https://github.com/opensciencegrid/topology/blob/master/mappings/project_institution.yaml),
-    edit that file to add the prefix and the organization you used.
     (You can skip this for XSEDE projects.)
 
-3.  Commit the new project file and submit a PR. 
+3.  Commit the new project file and, if modified, the project/institution mappings file, and submit a PR. 

--- a/docs/accounts-and-projects/projects.md
+++ b/docs/accounts-and-projects/projects.md
@@ -44,28 +44,28 @@ The project will also need to be added to the OSG topology at
 
 https://github.com/opensciencegrid/topology/tree/master/projects
 
-1. Clone the topology repository and `cd` into it.
-```
-git clone https://github.com/opensciencegrid/topology
-cd topology
-```
+1.  Clone the topology repository and `cd` into it.
 
+        git clone https://github.com/opensciencegrid/topology
+        cd topology
 
-2. To add a new project file, you will need to ensure you are working
-within your own (forked) version of the repository. If you have not already
-done so, fork the topology repository by visiting https://github.com/opensciencegrid/topology, 
-clicking "Fork". Detailed information for setting up and maintaining your fork can be found
-in the [GitHub documentation page](../documentation/github.md).
+2.  To add a new project file, you will need to ensure you are working
+    within your own (forked) version of the repository. If you have not already
+    done so, fork the topology repository by visiting https://github.com/opensciencegrid/topology, 
+    clicking "Fork". Detailed information for setting up and maintaining your fork can be found
+    in the [GitHub documentation page](../documentation/github.md).
 
-Within your forked repository, go into the projects folder and create a project file. 
-The project file should be named the same as the short (UNIX) project name. 
-It usually makes sense to copy from another project 
-file that was also created for an OSG Connect project so the 
-sponsor information is already correct.  Fill in the appropriate information.
+    Within your forked repository, go into the projects folder and create a project file. 
+    The project file should be named the same as the short (UNIX) project name. 
+    It usually makes sense to copy from another project 
+    file that was also created for an OSG Connect project so the 
+    sponsor information is already correct.  Fill in the appropriate information.
 
-Note: some projects may have `ID` or `Name` fields; these are no longer necessary.
+    Note: some projects may have `ID` or `Name` fields; these are no longer necessary.
 
-In order to maintain consistency in organization naming structure, please use the `bin/list_organizations` 
-function to ensure the name you are using matches this list.
+    In order to maintain consistency in organization naming structure, please use the `bin/list_organizations` 
+    function to ensure the name you are using matches this list.
 
-3. Commit the new project file and submit a PR. 
+    
+
+3.  Commit the new project file and submit a PR. 


### PR DESCRIPTION
Various tweaks to the Projects page mostly for the Topology section:

- You no longer have to enter Name or ID, or run bin/next_project_id
- Formatting tweaks to make the step numbers in the topology section work
- Add info about the Project/Institutions mapping file (mappings/project_institution.yaml)
